### PR TITLE
Added millisecond-precision to timestamp function

### DIFF
--- a/src/avnet/iotconnect/sdk/sdklib/util.py
+++ b/src/avnet/iotconnect/sdk/sdklib/util.py
@@ -12,7 +12,8 @@ from typing import get_type_hints, Type, Union, TypeVar
 
 
 def to_iotconnect_time_str(ts: datetime) -> str:
-    return ts.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    ns_str = str(int(ts.microsecond / 1000))
+    return ts.strftime(f"%Y-%m-%dT%H:%M:%S.{ns_str}Z")
 
 
 def dict_filter_empty(input_dict: dict):

--- a/src/avnet/iotconnect/sdk/sdklib/util.py
+++ b/src/avnet/iotconnect/sdk/sdklib/util.py
@@ -12,8 +12,8 @@ from typing import get_type_hints, Type, Union, TypeVar
 
 
 def to_iotconnect_time_str(ts: datetime) -> str:
-    ns_str = str(int(ts.microsecond / 1000))
-    return ts.strftime(f"%Y-%m-%dT%H:%M:%S.{ns_str}Z")
+    ms_str = f"{ts.microsecond // 1000:03d}"
+    return ts.strftime(f"%Y-%m-%dT%H:%M:%S.{ms_str}Z")
 
 
 def dict_filter_empty(input_dict: dict):


### PR DESCRIPTION
The to_iotconnect_time_str function in util.py currently fills in zeros for the milliseconds. The to_iotconnect_time_str function in this branch allows the milliseconds field to be accurately populated for enhanced precision on high-frequency applications.